### PR TITLE
Add BACKEND_API and ELECTRS_API_URL ENV lines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,8 @@ ENV BITCOIN_NODE_PORT 8332
 ENV BITCOIN_NODE_USER bitcoinuser
 ENV BITCOIN_NODE_PASS bitcoinpass
 ENV TX_PER_SECOND_SPAN_SECONDS 150
+ENV BACKEND_API bitcoind
+ENV ELECTRS_API_URL https://www.blockstream.info/api
 
 RUN cd /mempool.space/frontend/ && \
     npm run build && \


### PR DESCRIPTION
Adds BACKEND_API and ELECTRS_API_URL environment variables which will be populated into backend/mempool-config.json on startup.

This will allow docker users to easily switch to electrs mode and specify a server if they have a need to do so.